### PR TITLE
Fix ignoring files

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -131,8 +131,12 @@ func (w *watcher) start() {
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if contains(w.pm.conf.Ignore, path) {
 			logger.Debugf("Ignoring %s\n", path)
-			return filepath.SkipDir
-		} else if info.IsDir() && !contains(w.pm.conf.Ignore, path) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.IsDir() {
 			return watcher.Add(path)
 		}
 


### PR DESCRIPTION
Currently, trying to ignore files results in panic:

```bash
~/go/src/github.com/hypnoglow/dotbro master
ή rerun -v -i main.go
 git/ivp/rer 01:18:00 ★[DEBU] ▶ Ignoring /home/hypnoglow/go/src/github.com/hypnoglow/dotbro/main.go
 git/ivp/rer 01:18:00 ☹[PANI] ▶ Error while reading list of files to listen! skip this directory
panic: Error while reading list of files to listen! %s

goroutine 1 [running]:
panic(0x5e3ac0, 0xc420011d00)
	/usr/lib/go/src/runtime/panic.go:500 +0x1a1
github.com/ivpusic/golog.(*Logger).Panicf(0xc42009a500, 0x63ae4c, 0x2f, 0xc4200e5df8, 0x1, 0x1)
	/home/hypnoglow/go/src/github.com/ivpusic/golog/logger.go:315 +0x1d2
main.(*watcher).start(0xc420012d60)
	/home/hypnoglow/go/src/github.com/ivpusic/rerun/watcher.go:143 +0x39f
main.main()
	/home/hypnoglow/go/src/github.com/ivpusic/rerun/main.go:51 +0x28e
```

The RP fixes this issue.