### PR TITLE
Add support for default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ and then
 rerun -c conf.json
 ```
 
+Rerun supports default config loading: if a file with name `.rerun.json`
+exists in your project directory (from whence you execute rerun) - it will
+be automatically loaded without a need to specify `-c` flag.
+
 #### CLI + JSON
 If the same option is provided by cli flag and json config, one from cli will survive.
 

--- a/conf.go
+++ b/conf.go
@@ -8,8 +8,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"os"
 
 	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	defaultConfigPath string = ".rerun.json"
 )
 
 var (
@@ -27,6 +32,22 @@ type config struct {
 	Suffixes []string
 	Attrib   bool
 	build    string
+}
+
+func newConfig() (*config, error) {
+	if len(*confPath) > 0 {
+		return parseConf(*confPath)
+	}
+
+	if _, err := os.Stat(defaultConfigPath); err != nil {
+		if os.IsNotExist(err) {
+			return new(config), nil;
+		}
+
+		return nil, err
+	}
+
+	return parseConf(defaultConfigPath)
 }
 
 func parseConf(path string) (*config, error) {
@@ -50,15 +71,9 @@ func loadConfiguration() (*config, error) {
 		kingpin.Parse()
 	}
 
-	conf := &config{}
-	var err error
-
-	if len(*confPath) > 0 {
-		conf, err = parseConf(*confPath)
-
-		if err != nil {
-			return nil, err
-		}
+	conf, err := newConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	if len(*ignore) > 0 {

--- a/conf_test.go
+++ b/conf_test.go
@@ -33,8 +33,8 @@ func TestParseConfWithCliArgs(t *testing.T) {
 	assert.True(t, len(cnf.Ignore) >= 2)
 	pathPrefix := os.Getenv("GOPATH") + "/src/github.com/ivpusic/rerun"
 
-	assert.True(t, contains([]string{pathPrefix + "/path1", pathPrefix + "/path2"}, cnf.Ignore[0]))
-	assert.True(t, contains([]string{pathPrefix + "/path1", pathPrefix + "/path2"}, cnf.Ignore[1]))
+	assert.True(t, contains(cnf.Ignore, pathPrefix + "/path1"))
+	assert.True(t, contains(cnf.Ignore, pathPrefix + "/path2"))
 	AssertArraysEq(t, []string{"arg1", "arg2"}, cnf.Args)
 	AssertArraysEq(t, []string{".go", ".html"}, cnf.Suffixes)
 


### PR DESCRIPTION
I thought it would be convenient if you could run `rerun` without specifying config argument, and it would read from default file `.rerun.json` which is located in your project repository.

How do you like it?